### PR TITLE
feat: block categories and variant groups for Core Production and Core Survival

### DIFF
--- a/Mods/Sturmgrenadier Core Production/Data/BlockCategories.sbc
+++ b/Mods/Sturmgrenadier Core Production/Data/BlockCategories.sbc
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <CategoryClasses>
+
+        <!--
+            Sturmgrenadier Core Production - Block Categories
+            Adds third-party production mod blocks into vanilla G-menu categories.
+            Workshop mods covered:
+              3369254538 - ModCubeBlocks Refinery x10 [SG Adjuster] (ModCubeBlockLargeRefineryx10)
+              3369254384 - ModCubeBlocks Upgrade Module [SG Adjuster] (Productivity/Effectiveness/Energy x2/4/8/16)
+        -->
+
+        <!-- Modded refinery and upgrade modules → vanilla Production category -->
+        <Category xsi:type="MyObjectBuilder_GuiBlockCategoryDefinition">
+            <Id>
+                <TypeId>GuiBlockCategoryDefinition</TypeId>
+                <SubtypeId/>
+            </Id>
+            <DisplayName>DisplayName_Category_Production</DisplayName>
+            <Name>Section1_Position3_Production</Name>
+            <ItemIds>
+                <!-- ModCubeBlocks Refinery x10 -->
+                <string>Refinery/ModCubeBlockLargeRefineryx10</string>
+
+                <!-- ModCubeBlocks Productivity Modules -->
+                <string>UpgradeModule/ModCubeBlockProductivityModuleLargex2</string>
+                <string>UpgradeModule/ModCubeBlockProductivityModuleLargex4</string>
+                <string>UpgradeModule/ModCubeBlockProductivityModuleLargex8</string>
+                <string>UpgradeModule/ModCubeBlockProductivityModuleLargex16</string>
+
+                <!-- ModCubeBlocks Effectiveness Modules -->
+                <string>UpgradeModule/ModCubeBlockEffectivenessModuleLargex2</string>
+                <string>UpgradeModule/ModCubeBlockEffectivenessModuleLargex4</string>
+                <string>UpgradeModule/ModCubeBlockEffectivenessModuleLargex8</string>
+                <string>UpgradeModule/ModCubeBlockEffectivenessModuleLargex16</string>
+
+                <!-- ModCubeBlocks Energy Modules -->
+                <string>UpgradeModule/ModCubeBlockEnergyModuleLargex2</string>
+                <string>UpgradeModule/ModCubeBlockEnergyModuleLargex4</string>
+                <string>UpgradeModule/ModCubeBlockEnergyModuleLargex8</string>
+                <string>UpgradeModule/ModCubeBlockEnergyModuleLargex16</string>
+            </ItemIds>
+        </Category>
+
+    </CategoryClasses>
+</Definitions>

--- a/Mods/Sturmgrenadier Core Production/Data/BlockVariantGroups.sbc
+++ b/Mods/Sturmgrenadier Core Production/Data/BlockVariantGroups.sbc
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <BlockVariantGroups>
+
+        <!--
+            Sturmgrenadier Core Production - Block Variant Groups
+            Extends vanilla production and module scroll groups with modded blocks.
+            BVGs are non-additive — all vanilla blocks must be included or they disappear.
+            DisplayName MUST use a vanilla localization key (DisplayName_*) or DisplayNameEnum is null → crash.
+
+            Mods required:
+              3369254538 - ModCubeBlocks Refinery x10 [SG Adjuster]
+              3369254384 - ModCubeBlocks Upgrade Module [SG Adjuster]
+        -->
+
+        <!-- Extends the vanilla refinery scroll group with the modded x10 refinery -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="RefineryGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\refinery.dds</Icon>
+            <DisplayName>DisplayName_Block_Refinery</DisplayName>
+            <Description>Description_Refinery</Description>
+            <Blocks>
+                <!-- Vanilla refineries (must be preserved) -->
+                <Block Type="MyObjectBuilder_Refinery" Subtype="LargeRefinery" />
+                <Block Type="MyObjectBuilder_Refinery" Subtype="LargeRefineryIndustrial" />
+                <Block Type="MyObjectBuilder_Refinery" Subtype="Blast Furnace" />
+                <!-- ModCubeBlocks Refinery x10 -->
+                <Block Type="MyObjectBuilder_Refinery" Subtype="ModCubeBlockLargeRefineryx10" />
+            </Blocks>
+        </BlockVariantGroup>
+
+        <!-- Productivity modules: vanilla base → modded tiers x2/4/8/16 -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="ProductivityModuleGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\UpgradeProductivity.dds</Icon>
+            <DisplayName>DisplayName_Block_ProductivityModule</DisplayName>
+            <Description>Description_ProductivityModule</Description>
+            <Blocks>
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="LargeProductivityModule" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockProductivityModuleLargex2" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockProductivityModuleLargex4" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockProductivityModuleLargex8" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockProductivityModuleLargex16" />
+            </Blocks>
+        </BlockVariantGroup>
+
+        <!-- Effectiveness modules: vanilla base → modded tiers x2/4/8/16 -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="EffectivenessModuleGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\UpgradeEffectiveness.dds</Icon>
+            <DisplayName>DisplayName_Block_EffectivenessModule</DisplayName>
+            <Description>Description_EffectivenessModule</Description>
+            <Blocks>
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="LargeEffectivenessModule" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEffectivenessModuleLargex2" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEffectivenessModuleLargex4" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEffectivenessModuleLargex8" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEffectivenessModuleLargex16" />
+            </Blocks>
+        </BlockVariantGroup>
+
+        <!-- Energy modules: vanilla base → modded tiers x2/4/8/16 -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="EnergyModuleGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\UpgradeEnergy.dds</Icon>
+            <DisplayName>DisplayName_Block_PowerEfficiencyModule</DisplayName>
+            <Description>Description_PowerEfficiencyModule</Description>
+            <Blocks>
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="LargeEnergyModule" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEnergyModuleLargex2" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEnergyModuleLargex4" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEnergyModuleLargex8" />
+                <Block Type="MyObjectBuilder_UpgradeModule" Subtype="ModCubeBlockEnergyModuleLargex16" />
+            </Blocks>
+        </BlockVariantGroup>
+
+    </BlockVariantGroups>
+</Definitions>

--- a/Mods/Sturmgrenadier Core Survival/Data/BlockCategories.sbc
+++ b/Mods/Sturmgrenadier Core Survival/Data/BlockCategories.sbc
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <CategoryClasses>
+
+        <!--
+            Sturmgrenadier Core Survival - Block Categories
+            Adds third-party survival mod blocks into vanilla G-menu categories.
+            Workshop mods covered:
+              3562249355 - Vertical Farm Plot (VFP) (VerticalFarmPlot, InsetFarmPlot)
+              2294559988 - Wardrobe and Kit Locker (Wardrobe, SG_Wardrobe, Damaged_Wardrobe, SG_Damaged_Wardrobe,
+                           Kit_Locker, SG_Kit_Locker, Damaged_Kit_Locker, SG_Damaged_Kit_Locker)
+              3566504208 - JS Apex Things - Laboratories (JSLabLarge, JSLabEquipment, JSLargeBlockLabDeskMicroscope)
+        -->
+
+        <!-- Modded farm plots and lab assemblers → vanilla Production category -->
+        <Category xsi:type="MyObjectBuilder_GuiBlockCategoryDefinition">
+            <Id>
+                <TypeId>GuiBlockCategoryDefinition</TypeId>
+                <SubtypeId>Production</SubtypeId>
+            </Id>
+            <DisplayName>DisplayName_Category_Production</DisplayName>
+            <Name>Section1_Position3_Production</Name>
+            <ItemIds>
+                <!-- Vertical Farm Plot -->
+                <string>FunctionalBlock/VerticalFarmPlot</string>
+                <string>FunctionalBlock/InsetFarmPlot</string>
+                <!-- JS Apex Laboratories -->
+                <string>Assembler/JSLabLarge</string>
+                <string>Assembler/JSLabEquipment</string>
+                <string>Assembler/JSLargeBlockLabDeskMicroscope</string>
+            </ItemIds>
+        </Category>
+
+        <!-- Wardrobe and Kit Locker blocks → vanilla Decorative category -->
+        <Category xsi:type="MyObjectBuilder_GuiBlockCategoryDefinition">
+            <Id>
+                <TypeId>GuiBlockCategoryDefinition</TypeId>
+                <SubtypeId>Decorative</SubtypeId>
+            </Id>
+            <DisplayName>DisplayName_Category_Decorative</DisplayName>
+            <Name>Section1_Position3_Decorative</Name>
+            <ItemIds>
+                <!-- Wardrobe and Kit Locker (large grid) -->
+                <string>MedicalRoom/Wardrobe</string>
+                <string>CubeBlock/Damaged_Wardrobe</string>
+                <string>CubeBlock/Kit_Locker</string>
+                <string>CubeBlock/Damaged_Kit_Locker</string>
+                <!-- Wardrobe and Kit Locker (small grid) -->
+                <string>MedicalRoom/SG_Wardrobe</string>
+                <string>CubeBlock/SG_Damaged_Wardrobe</string>
+                <string>CubeBlock/SG_Kit_Locker</string>
+                <string>CubeBlock/SG_Damaged_Kit_Locker</string>
+            </ItemIds>
+        </Category>
+
+    </CategoryClasses>
+</Definitions>

--- a/Mods/Sturmgrenadier Core Survival/Data/BlockVariantGroups.sbc
+++ b/Mods/Sturmgrenadier Core Survival/Data/BlockVariantGroups.sbc
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <BlockVariantGroups>
+
+        <!--
+            Sturmgrenadier Core Survival - Block Variant Groups
+            Extends vanilla scroll groups with modded blocks.
+            BVGs are non-additive — all vanilla blocks must be included or they disappear.
+            DisplayName MUST use a vanilla localization key (DisplayName_*) or DisplayNameEnum is null → crash.
+
+            Mods required:
+              3562249355 - Vertical Farm Plot (VFP)
+              2294559988 - Wardrobe and Kit Locker
+              3566504208 - JS Apex Things - Laboratories
+        -->
+
+        <!-- New farm plot scroll group: vanilla root → modded shape variants -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="FarmPlotGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\FarmPlot.dds</Icon>
+            <DisplayName>DisplayName_Block_FarmPlot</DisplayName>
+            <Description>Description_FarmPlot</Description>
+            <Blocks>
+                <Block Type="MyObjectBuilder_FunctionalBlock" Subtype="LargeBlockFarmPlot" />
+                <Block Type="MyObjectBuilder_FunctionalBlock" Subtype="VerticalFarmPlot" />
+                <Block Type="MyObjectBuilder_FunctionalBlock" Subtype="InsetFarmPlot" />
+            </Blocks>
+        </BlockVariantGroup>
+
+        <!-- Extends the vanilla lockers/armory scroll group with wardrobes and kit lockers -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="LockersGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\WeaponRack.dds</Icon>
+            <DisplayName>DisplayName_Block_WeaponRack</DisplayName>
+            <Description>Description_WeaponRack</Description>
+            <Blocks>
+                <!-- Vanilla locker/armory blocks (must be preserved) -->
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLockerRoom" />
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLockerRoomCorner" />
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLockers" />
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockWeaponRack" />
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="SmallBlockWeaponRack" />
+                <Block Type="MyObjectBuilder_TerminalBlock" Subtype="SmallBlockFirstAidCabinet" />
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockInsetBookshelf" />
+                <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLabCabinet" />
+                <Block Type="MyObjectBuilder_TerminalBlock" Subtype="LargeFreezer" />
+                <!-- Wardrobe and Kit Locker (large grid) -->
+                <Block Type="MyObjectBuilder_MedicalRoom" Subtype="Wardrobe" />
+                <Block Type="MyObjectBuilder_CubeBlock" Subtype="Damaged_Wardrobe" />
+                <Block Type="MyObjectBuilder_CubeBlock" Subtype="Kit_Locker" />
+                <Block Type="MyObjectBuilder_CubeBlock" Subtype="Damaged_Kit_Locker" />
+                <!-- Wardrobe and Kit Locker (small grid) -->
+                <Block Type="MyObjectBuilder_MedicalRoom" Subtype="SG_Wardrobe" />
+                <Block Type="MyObjectBuilder_CubeBlock" Subtype="SG_Damaged_Wardrobe" />
+                <Block Type="MyObjectBuilder_CubeBlock" Subtype="SG_Kit_Locker" />
+                <Block Type="MyObjectBuilder_CubeBlock" Subtype="SG_Damaged_Kit_Locker" />
+            </Blocks>
+        </BlockVariantGroup>
+
+        <!-- Extends the vanilla assembler scroll group with JS Apex lab assemblers -->
+        <BlockVariantGroup>
+            <Id Type="MyObjectBuilder_BlockVariantGroup" Subtype="AssemblerGroup" />
+            <Icon>Textures\GUI\Icons\Cubes\assembler.dds</Icon>
+            <DisplayName>DisplayName_Block_Assembler</DisplayName>
+            <Description>Description_Assembler</Description>
+            <Blocks>
+                <!-- Vanilla assemblers (must be preserved) -->
+                <Block Type="MyObjectBuilder_Assembler" Subtype="LargeAssembler" />
+                <Block Type="MyObjectBuilder_Assembler" Subtype="LargeAssemblerIndustrial" />
+                <Block Type="MyObjectBuilder_Assembler" Subtype="BasicAssembler" />
+                <!-- JS Apex Laboratories -->
+                <Block Type="MyObjectBuilder_Assembler" Subtype="JSLabLarge" />
+                <Block Type="MyObjectBuilder_Assembler" Subtype="JSLabEquipment" />
+                <Block Type="MyObjectBuilder_Assembler" Subtype="JSLargeBlockLabDeskMicroscope" />
+            </Blocks>
+        </BlockVariantGroup>
+
+    </BlockVariantGroups>
+</Definitions>


### PR DESCRIPTION
## Summary

- **Core Production** — adds `BlockCategories.sbc` and `BlockVariantGroups.sbc` integrating ModCubeBlocks Refinery x10 (3369254538) and Upgrade Modules (3369254384) into the vanilla Production G-menu tab; extends `RefineryGroup` scroll group and splits upgrade modules into three separate per-type scroll groups (`ProductivityModuleGroup`, `EffectivenessModuleGroup`, `EnergyModuleGroup`) each with vanilla base → modded x2/4/8/16 tiers
- **Core Survival** — adds `BlockCategories.sbc` and `BlockVariantGroups.sbc` integrating Vertical Farm Plot (3562249355), Wardrobe & Kit Locker (2294559988), and JS Apex Laboratories (3566504208); adds new `FarmPlotGroup` scroll group, extends `LockersGroup` with wardrobes/kit lockers, and extends `AssemblerGroup` with JS lab assemblers

## Test plan

- [x] Load Core Production mod in-game, confirm modded refinery appears in Production G-menu tab and scrolls within the refinery group
- [x] Confirm three separate module scroll groups (Productivity, Effectiveness, Energy) each show vanilla base → x2 → x4 → x8 → x16
- [x] Load Core Survival mod in-game, confirm farm plots appear in Production tab and scroll as FarmPlotGroup
- [x] Confirm wardrobes and kit lockers appear in Decorative tab and scroll within LockersGroup alongside vanilla armory blocks
- [x] Confirm JS lab assemblers appear in Production tab and scroll within AssemblerGroup alongside vanilla assemblers

🤖 Generated with [Claude Code](https://claude.com/claude-code)