### PR TITLE
fix: show percentage in Components when ShowBars=False and ShowRatio=…

### DIFF
--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_SurfaceDrawer.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_SurfaceDrawer.cs
@@ -177,7 +177,10 @@ namespace MahrianeIndustries.LCDInfo
                 {
                     displayName = MahUtillities.GetSubstring(displayName, surfaceData, true);
                     WriteTextSprite(ref frame, position, surfaceData, displayName, TextAlignment.LEFT, surfaceData.surface.ScriptForegroundColor);
-                    WriteTextSprite(ref frame, position, surfaceData, MahDefinitions.KiloFormat(currentAmount), TextAlignment.RIGHT, surfaceData.surface.ScriptForegroundColor);
+                    if (surfaceData.showRatio && minAmount > 0)
+                        WriteTextSprite(ref frame, position, surfaceData, $"{(((double)currentAmount / minAmount) * 100).ToString("#0.0")} %", TextAlignment.RIGHT, surfaceData.surface.ScriptForegroundColor);
+                    else
+                        WriteTextSprite(ref frame, position, surfaceData, MahDefinitions.KiloFormat(currentAmount), TextAlignment.RIGHT, surfaceData.surface.ScriptForegroundColor);
                     position += surfaceData.newLine;
                 }
                 else

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_SurfaceDrawer.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_SurfaceDrawer.cs
@@ -177,7 +177,10 @@ namespace MahrianeIndustries.LCDInfo
                 {
                     displayName = MahUtillities.GetSubstring(displayName, surfaceData, true);
                     WriteTextSprite(ref frame, position, surfaceData, displayName, TextAlignment.LEFT, surfaceData.surface.ScriptForegroundColor);
-                    WriteTextSprite(ref frame, position, surfaceData, MahDefinitions.KiloFormat(currentAmount), TextAlignment.RIGHT, surfaceData.surface.ScriptForegroundColor);
+                    if (surfaceData.showRatio && minAmount > 0)
+                        WriteTextSprite(ref frame, position, surfaceData, $"{(((double)currentAmount / minAmount) * 100).ToString("#0.0")} %", TextAlignment.RIGHT, surfaceData.surface.ScriptForegroundColor);
+                    else
+                        WriteTextSprite(ref frame, position, surfaceData, MahDefinitions.KiloFormat(currentAmount), TextAlignment.RIGHT, surfaceData.surface.ScriptForegroundColor);
                     position += surfaceData.newLine;
                 }
                 else


### PR DESCRIPTION
…True

DrawItemSprite ignored ShowRatio when bars were disabled, always displaying raw counts. Now checks showRatio and renders percentage against minAmount threshold when enabled.

Fixes Godimas101/se-mods#6