### PR TITLE
fix: preserve SearchId and ExcludeIds when config rebuilds for modded…

### DIFF
--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Ammo.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Ammo.cs
@@ -120,8 +120,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ AMMO - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Cargo.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Cargo.cs
@@ -160,8 +160,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ CARGO - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Components.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Components.cs
@@ -121,8 +121,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ COMPONENTS - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Container.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Container.cs
@@ -77,8 +77,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ CONTAINER - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Farming.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Farming.cs
@@ -135,8 +135,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ FARMING - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowSubgrids={surfaceData.showSubgrids}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Ingots.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Ingots.cs
@@ -119,8 +119,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ INGOTS - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Items.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Items.cs
@@ -135,8 +135,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ ITEMS - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Ores.cs
+++ b/Mods/InfoLCD - Apex Advanced/Data/Scripts/SG/MahLCDs_Summary_Ores.cs
@@ -119,8 +119,8 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ ORES - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine($"ShowHeader={surfaceData.showHeader}");
             sb.AppendLine($"ShowSummary={surfaceData.showSummary}");
             sb.AppendLine($"ShowMissing={surfaceData.showMissing}");

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Ammo.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Ammo.cs
@@ -122,10 +122,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ AMMO - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Cargo.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Cargo.cs
@@ -154,10 +154,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ CARGO - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Components.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Components.cs
@@ -115,10 +115,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ COMPONENTS - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Container.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Container.cs
@@ -77,10 +77,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ CONTAINER - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Farming.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Farming.cs
@@ -161,10 +161,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ FARMING - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Ingots.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Ingots.cs
@@ -121,10 +121,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ INGOTS - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Items.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Items.cs
@@ -129,10 +129,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ ITEMS - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);

--- a/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Ores.cs
+++ b/Mods/InfoLCD - Apex Update/Data/Scripts/SG/MahLCDs_Summary_Ores.cs
@@ -113,10 +113,10 @@ namespace MahrianeIndustries.LCDInfo
             sb.AppendLine($"[{CONFIG_SECTION_ID}]");
             sb.AppendLine();
             sb.AppendLine("; [ ORES - GENERAL OPTIONS ]");
-            sb.AppendLine("SearchId=*");
+            sb.AppendLine($"SearchId={(!string.IsNullOrEmpty(searchId) ? searchId : "*")}");
             sb.AppendLine("; Block name filter: Use '*' for all, or text to match block names (case-insensitive substring match)");
             sb.AppendLine("; Examples: 'Cargo' matches 'Main Cargo', 'Engineering,Medical' matches blocks containing either word");
-            sb.AppendLine("ExcludeIds=");
+            sb.AppendLine($"ExcludeIds={string.Join(",", excludeIds)}");
             sb.AppendLine("; Exclude blocks containing these words (comma-separated, case-insensitive)");
             sb.AppendLine("; Example: 'Airlock,Backup' excludes blocks with 'Airlock' or 'Backup' in their names");
             ConfigHelpers.AppendShowHeaderConfig(sb, surfaceData.showHeader);


### PR DESCRIPTION

CreateConfig() was called when a newly discovered modded item needed to be added to the config. It stripped the entire config section and rebuilt it with hardcoded SearchId=* and ExcludeIds=, wiping the user's filter settings. Now preserves the current searchId and excludeIds values.

Fixed across all 8 inventory screens in both Apex Update and Apex Advanced variants (16 files).

Fixes Godimas101/se-mods#7